### PR TITLE
Import React API from react instead of react-native

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,8 +8,9 @@
  */
 'use strict';
 
-var React = require('react-native');
-var { Animated, Touchable } = React;
+var React = require('react');
+var ReactNative = require('react-native');
+var { Animated, Touchable } = ReactNative;
 
 var EdgeInsetsPropType = React.PropTypes.shape({
   top: React.PropTypes.number,


### PR DESCRIPTION
As of React Native 0.26, the React API has to be imported from the react module (https://github.com/facebook/react-native/releases/tag/v0.26.0). This fixes the error `undefined is not an object (evaluating 'React.PropTypes.shape')` when importing  importing react-native-touchable-bounce.
